### PR TITLE
use code meanings from dicom standard

### DIFF
--- a/configs/TotalSegmentator/radiomicsFeaturesMaps.csv
+++ b/configs/TotalSegmentator/radiomicsFeaturesMaps.csv
@@ -1,19 +1,19 @@
 ,feature,pyradiomics_feature_class,pyradiomics_notes,quantity_CodingSchemeDesignator,quantity_CodeValue,quantity_CodeMeaning,units_CodingSchemeDesignator,units_CodeValue,units_CodeMeaning
 0,Elongation,shape,,IBSI,Q3CK,Elongation,UCUM,1,no units
 1,Flatness,shape,,IBSI,N17B,Flatness,UCUM,1,no units
-2,LeastAxisLength,shape,,IBSI,7J51,Least axis length,UCUM,mm,millimeter
-3,MajorAxisLength,shape,,IBSI,TDIC,Major axis length,UCUM,mm,millimeter
-4,Maximum3DDiameter,shape,https://pyradiomics.readthedocs.io/en/latest/features.html#radiomics.shape.RadiomicsShape.calculateDiameters,IBSI,L0JK,Maximum 3D diameter,UCUM,mm,millimeter
-5,MeshVolume,shape,,IBSI,RNU0,Volume,UCUM,mm3,cubic millimeter
-6,MinorAxisLength,shape,,IBSI,P9VJ,Minor axis length,UCUM,mm,millimeter
+2,LeastAxisLength,shape,,IBSI,7J51,Least Axis in 3D Length​,UCUM,mm,millimeter
+3,MajorAxisLength,shape,,IBSI,TDIC,Major Axis in 3D Length,UCUM,mm,millimeter
+4,Maximum3DDiameter,shape,https://pyradiomics.readthedocs.io/en/latest/features.html#radiomics.shape.RadiomicsShape.calculateDiameters,IBSI,L0JK,Maximum 3D Diameter of a Mesh,UCUM,mm,millimeter
+5,MeshVolume,shape,,IBSI,RNU0,Volume of Mesh,UCUM,mm3,cubic millimeter
+6,MinorAxisLength,shape,,IBSI,P9VJ,Minor Axis in 3D Length,UCUM,mm,millimeter
 7,Sphericity,shape,,IBSI,QCFX,Sphericity,UCUM,1,no units
-8,SurfaceArea,shape,Calculated using Marching Cubes,IBSI,C0JK,Surface area,UCUM,mm2,square millimeter
-9,SurfaceVolumeRatio,shape,,IBSI,2PR5,Surface to volume ratio,UCUM,/mm,per millimeter
-10,VoxelVolume,shape,,IBSI,YEKZ,Approximate volume,UCUM,mm3,cubic millimeter
+8,SurfaceArea,shape,Calculated using Marching Cubes,IBSI,C0JK,Surface Area of Mesh​,UCUM,mm2,square millimeter
+9,SurfaceVolumeRatio,shape,,IBSI,2PR5,Surface to Volume Ratio,UCUM,/mm,per millimeter
+10,VoxelVolume,shape,,IBSI,YEKZ,Volume from Voxel Summation,UCUM,mm3,cubic millimeter
 11,10Percentile,firstorder,,IBSI,QG58,10th percentile,UCUM,[hnsf'U],Hounsfield Unit
 12,90Percentile,firstorder,,IBSI,8DWT,90th percentile,UCUM,[hnsf'U],Hounsfield Unit
 13,Energy,firstorder,,IBSI,N8CA,Energy,UCUM,[hnsf'U]2,square Hounsfield Unit
-14,Entropy,firstorder,,IBSI,TLU2,Intensity histogram entropy,UCUM,1,no units
+14,Entropy,firstorder,,IBSI,TLU2,Intensity Histogram Entropy,UCUM,1,no units
 15,InterquartileRange,firstorder,,IBSI,SALO,Interquartile range,UCUM,[hnsf'U],Hounsfield Unit
 16,Maximum,firstorder,,IBSI,84IY,Maximum grey level,UCUM,[hnsf'U],Hounsfield Unit
 17,MeanAbsoluteDeviation,firstorder,,IBSI,4FUA,Mean absolute deviation,UCUM,[hnsf'U],Hounsfield Unit


### PR DESCRIPTION
Upon suggestion to use code meanings from DICOM standard instead of IBSI, I looked up the code meanings at https://dicom.nema.org/medical/dicom/current/output/pdf/part16.pdf#CID%207476%20Gray%20Level%20Size%20Zone%20Based%20Feature

I found that code meanings were more 'complete' in the DICOM standard. While I could find code meanings for all shape featues, first-order features in the DICOM standard contained only codes when pyradiomics features are used with arbitrary units i.e Intensity Histogram features. More on the arbitrary vs calibrated units can be found in #34. This makes me wonder if my understanding of arbitrary vs calibrated is correct or not.