### PR TITLE
ENH: revisit encoding of algorithm in SR

### DIFF
--- a/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
+++ b/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
@@ -3,6 +3,15 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "view-in-github"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/ImagingDataCommons/CloudSegmentator/blob/main/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "EHS1DmzV54av"
       },
       "source": [
@@ -1777,32 +1786,6 @@
         "!lz4 runtime.csv dicomsegAndRadiomicsSR_UsageMetrics.lz4\n",
         "runtime_stats"
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### **WIP: DCMTK install**\n",
-        "\n",
-        "Unfortunately, even after setting the path for the dictionary, `dsrdump` segfaults. Not sure why."
-      ],
-      "metadata": {
-        "id": "xFxgXFp_oGij"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "if 'google.colab' in sys.modules:\n",
-        "  !cd /content && wget https://github.com/DCMTK/dcmtk/releases/download/DCMTK-3.6.6/dcmtk-3.6.6.tar.gz\n",
-        "  !bunzip dcmtk-3.6.6.tar.gz\n",
-        "  !tar -xvf dcmtk-3.6.6.tar\n",
-        "  !export DCMDICTPATH=/content/dcmtk-3.6.8-linux-x86_64-static/share/dcmtk-3.6.8/acrnema.dic"
-      ],
-      "metadata": {
-        "id": "dQL6eDKeoHe7"
-      },
-      "execution_count": null,
-      "outputs": []
     }
   ],
   "metadata": {

--- a/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
+++ b/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
@@ -3,15 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/ImagingDataCommons/CloudSegmentator/blob/main/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "EHS1DmzV54av"
       },
       "source": [
@@ -316,7 +307,7 @@
       "source": [
         "### **Initialize IDC Client**\n",
         "\n",
-        "We use idc-client pypi package to handle downloading data from IDC. \n",
+        "We use idc-client pypi package to handle downloading data from IDC.\n",
         "In this notebook, we are using version 0.2.8 which contains the index from idc version 17\n",
         "\n",
         "Learn more about idc-index at ttps://github.com/ImagingDataCommons/idc-index"
@@ -636,8 +627,9 @@
         "\n",
         "    # Run the appropriate converter command and capture the output\n",
         "\n",
+        "    # use just SeriesInstanceUID for the output file name to make it more readable\n",
         "    result = subprocess.run(\n",
-        "        f\"dcm2niix -z y -f %j_%p_%t_%s -b n -m y -o dcm2niix/{series_id} idc_data/{series_id}\",\n",
+        "        f\"dcm2niix -z y -f %j -b n -m y -o dcm2niix/{series_id} idc_data/{series_id}\",\n",
         "        shell=True,\n",
         "        capture_output=True,\n",
         "        text=True,\n",
@@ -645,6 +637,17 @@
         "    print(result.stdout)\n",
         "    print(\"\\n Conversion successful\")\n"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!dcm2niix -help"
+      ],
+      "metadata": {
+        "id": "iZGlfpxlkb_3"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -847,7 +850,9 @@
         "        # Enable the shape and firstorder features\n",
         "        extractor.disableAllFeatures()\n",
         "        extractor.enableFeaturesByName(\n",
-        "            shape=shape_features, firstorder=firstorder_features\n",
+        "            # NB: while testing, use the line below to reduce the number of features to be extracted\n",
+        "            # firstorder=firstorder_features[:3]\n",
+        "            firstorder=firstorder_features, shape=shape_features\n",
         "        )\n",
         "        # Extract the features\n",
         "        raw_features = extractor.execute(\n",
@@ -911,6 +916,10 @@
         "    labels = [\n",
         "        int(x) for x in np.unique(nib.load(seg_file).get_fdata()).tolist() if x != 0\n",
         "    ]\n",
+        "\n",
+        "    # NB: while testing, use the line below to process just a subset of segments\n",
+        "    # labels = labels[:3]\n",
+        "    print(\"Total number of labels: \"+str(len(labels)))\n",
         "\n",
         "    # Define the function to be applied to each label\n",
         "    func = partial(extract_radiomics_features_from_one_label, seg_file, ct_file, label_id_body_part_df)\n",
@@ -1041,7 +1050,8 @@
         "    in IBSI kurtosis is subracted by 3 units\n",
         "    https://pubs.rsna.org/doi/suppl/10.1148/radiol.2020191145/suppl_file/IBSI_Reference_Manual.pdf#.3.4%20(Excess)%20intensity%20kurtosis\n",
         "    '''\n",
-        "    radiomics_df['Kurtosis']=radiomics_df['Kurtosis']-3\n",
+        "    if 'Kurtosis' in radiomics_df.columns:\n",
+        "      radiomics_df['Kurtosis']=radiomics_df['Kurtosis']-3\n",
         "\n",
         "    return radiomics_df\n"
       ]
@@ -1205,6 +1215,8 @@
         "\n",
         "    for segment_id in range(0, num_segments):\n",
         "\n",
+        "        print(\"processing segment \"+str(segment_id))\n",
+        "\n",
         "        ReferencedSegment = int(\n",
         "            radiomics_features[\"seg_segment_number\"].values[segment_id]\n",
         "        )  # referencedsegment must be an integer according to the schema.\n",
@@ -1253,6 +1265,10 @@
         "                    segment_row[\"SegmentedPropertyTypeCodeSequence.CodeMeaning\"].iloc[0]\n",
         "                ),\n",
         "            },\n",
+        "            \"measurementAlgorithmIdentification\": {\n",
+        "                \"AlgorithmName\": \"pyradiomics\",\n",
+        "                \"AlgorithmVersion\": str(pyradiomics_version_number)\n",
+        "            }\n",
         "        }\n",
         "\n",
         "        laterality_dict = {\n",
@@ -1289,11 +1305,19 @@
         "\n",
         "        # For each measurement per region segment\n",
         "        for n in range(0, len(feature_list)):\n",
+        "            if not feature_list[n] in radiomics_features.columns:\n",
+        "                print(\"failed to find feature \"+features_code_mapping_df[\"feature\"]+\" - skipping\")\n",
+        "                continue\n",
         "            measurement_dict = {}\n",
         "            row = radiomics_features.loc[radiomics_features[\"body_part\"] == FindingSite]\n",
         "            feature_row = features_code_mapping_df.loc[\n",
         "                features_code_mapping_df[\"feature\"] == feature_list[n]\n",
         "            ]\n",
+        "            # continue if feature_row is empty\n",
+        "            if row.empty:\n",
+        "                print(\"failed to find feature \"+features_code_mapping_df[\"feature\"])\n",
+        "                continue\n",
+        "\n",
         "            value = str(np.round(row[feature_list[n]].values[0], 3))\n",
         "            measurement_dict[\"value\"] = value\n",
         "            measurement_dict[\"quantity\"] = {}\n",
@@ -1316,13 +1340,6 @@
         "            measurement_dict[\"units\"][\"CodeMeaning\"] = str(\n",
         "                feature_row[\"units_CodeMeaning\"].values[0]\n",
         "            )\n",
-        "            measurement_dict[\"measurementAlgorithmIdentification\"] = {}\n",
-        "            measurement_dict[\"measurementAlgorithmIdentification\"][\n",
-        "                \"AlgorithmName\"\n",
-        "            ] = \"pyradiomics\"\n",
-        "            measurement_dict[\"measurementAlgorithmIdentification\"][\n",
-        "                \"AlgorithmVersion\"\n",
-        "            ] = str(pyradiomics_version_number)\n",
         "            measurement.append(measurement_dict)\n",
         "\n",
         "        measurement_combined_dict = {}\n",
@@ -1650,7 +1667,9 @@
         "id": "xqxRLpdSQAQ5"
       },
       "source": [
-        "### **Convert Inference NIFTI file to DICOM_SEG Object**"
+        "### **Convert Inference NIFTI file to DICOM_SEG Object**\n",
+        "\n",
+        "If you want to rerun the cell below, rerun \"Input files for local testing\" cells first."
       ]
     },
     {
@@ -1776,7 +1795,8 @@
   "metadata": {
     "celltoolbar": "Tags",
     "colab": {
-      "provenance": []
+      "provenance": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",

--- a/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
+++ b/workflows/TotalSegmentator/Notebooks/dicomsegAndRadiomicsSR_Notebook.ipynb
@@ -640,17 +640,6 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!dcm2niix -help"
-      ],
-      "metadata": {
-        "id": "iZGlfpxlkb_3"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
       "execution_count": null,
       "metadata": {
         "id": "whJ5vtbiQQvO"
@@ -1214,8 +1203,6 @@
         "    measurement_across_segments_combined = []\n",
         "\n",
         "    for segment_id in range(0, num_segments):\n",
-        "\n",
-        "        print(\"processing segment \"+str(segment_id))\n",
         "\n",
         "        ReferencedSegment = int(\n",
         "            radiomics_features[\"seg_segment_number\"].values[segment_id]\n",
@@ -1790,6 +1777,32 @@
         "!lz4 runtime.csv dicomsegAndRadiomicsSR_UsageMetrics.lz4\n",
         "runtime_stats"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### **WIP: DCMTK install**\n",
+        "\n",
+        "Unfortunately, even after setting the path for the dictionary, `dsrdump` segfaults. Not sure why."
+      ],
+      "metadata": {
+        "id": "xFxgXFp_oGij"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "if 'google.colab' in sys.modules:\n",
+        "  !cd /content && wget https://github.com/DCMTK/dcmtk/releases/download/DCMTK-3.6.6/dcmtk-3.6.6.tar.gz\n",
+        "  !bunzip dcmtk-3.6.6.tar.gz\n",
+        "  !tar -xvf dcmtk-3.6.6.tar\n",
+        "  !export DCMDICTPATH=/content/dcmtk-3.6.8-linux-x86_64-static/share/dcmtk-3.6.8/acrnema.dic"
+      ],
+      "metadata": {
+        "id": "dQL6eDKeoHe7"
+      },
+      "execution_count": null,
+      "outputs": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
Instead of encoding algorithm details for each individual feature in radiomics features SR, do this at the level of the measurement group. This helps significantly reduce the size of the SR content sequence, which should help work around the 1MB SQ limit of Google Healthcare.

In the process of implementing this refinement, clean up the code to make it possible to complete the test runs much faster, and make the code a bit more robust.