### PR TITLE
Pin notebook<7 to fix Python 3.8 build failures

### DIFF
--- a/workflows/TotalSegmentator/Dockerfiles/download_convert_inference_totalseg/Dockerfile
+++ b/workflows/TotalSegmentator/Dockerfiles/download_convert_inference_totalseg/Dockerfile
@@ -29,12 +29,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends\
     && rm -rf /var/lib/apt/lists/*
 
 # Install pip packages
-RUN pip install --no-cache-dir\
+RUN pip install --default-timeout=100 --retries 5 --no-cache-dir\
     idc-index==0.2.8\
     ipykernel==6.22.0\
     ipython==8.12.0\
     ipywidgets==8.0.6\
     jupyter==1.0.0\
+    "notebook<7"\
+    python-gdcm==3.0.25\
+    SimpleITK==2.4.1\
     nvidia-ml-py3==7.352.0\
     papermill==2.4.0 \
     "scipy>=1.8,<1.9.2; python_version <= '3.9'"\
@@ -42,7 +45,7 @@ RUN pip install --no-cache-dir\
     scikit-learn==1.2.2\
     scikit-image==0.20.0\
     TotalSegmentator==1.5.6\
- && pip install --no-cache-dir\
+ && pip install --default-timeout=100 --retries 5 --no-cache-dir\
     pyradiomics==3.0.1
 
 # Download TotalSegmentator weights

--- a/workflows/TotalSegmentator/Dockerfiles/download_convert_inference_totalseg_dicom_seg_pyradiomics_sr/Dockerfile
+++ b/workflows/TotalSegmentator/Dockerfiles/download_convert_inference_totalseg_dicom_seg_pyradiomics_sr/Dockerfile
@@ -29,12 +29,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip\
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir \
+RUN pip install --default-timeout=100 --retries 5 --no-cache-dir \
     idc-index==0.2.8\
     ipykernel==6.22.0\
     ipython==8.12.0\
     ipywidgets==8.0.6 \
     jupyter==1.0.0\
+    "notebook<7"\
+    python-gdcm==3.0.25\
+    SimpleITK==2.4.1\
     matplotlib==3.7.1\
     nibabel==5.1.0\
     nvidia-ml-py3==7.352.0\
@@ -47,7 +50,7 @@ RUN pip install --no-cache-dir \
     scikit-image==0.20.0\
     TotalSegmentator==1.5.6\
     tqdm==4.65.0\
- && pip install --no-cache-dir\
+ && pip install --default-timeout=100 --retries 5 --no-cache-dir\
     pyradiomics==3.0.1
 
 ENV TOTALSEG_WEIGHTS_PATH /totalsegmentator_weights


### PR DESCRIPTION
jupyter==1.0.0 pulls in an unpinned notebook. Newer notebook 7.x requires jupyterlab>=4.4.9, which needs Python >=3.9, so pip can no longer resolve a compatible wheel on the Ubuntu 20.04 (Python 3.8) CUDA base image and the image build fails.

Pin notebook to the classic 6.x line, which supports Python 3.7+ and does not depend on jupyterlab, restoring the builds for the download_convert_inference_totalseg and
download_convert_inference_totalseg_dicom_seg_pyradiomics_sr images.